### PR TITLE
Link to CMake recommendations more explicitly

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -9,10 +9,11 @@ Here are our suggested default choices for build systems and third party librari
   - de facto standard for open source software
   - start from our [C++ template repository](https://github.com/ssciwr/cpp-project-template)
   - private repos also available
-- Build system: [CMake](cmake.md)
+- Build system: [CMake](https://cmake.org/)
   - de facto standard for C++
   - widely used and supported
   - cross-platform
+  - Have a look at [our dedicated CMake recommendations](cmake.md)
 - Testing framework: [Catch2](https://github.com/catchorg/Catch2)
   - simple to setup and to use
 - Continuous Integration: [GitHub Actions](https://github.com/features/actions)


### PR DESCRIPTION
The fact that we have a dedicated CMake recommendations page was shadowed by the link text being quite boring - I would have expected a link to the CMake website. The commit makes it more clear that it is worth clicking!